### PR TITLE
feat: scaffold Nest backend with /health + Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,6 @@ out/
 next-env.d.ts
 
 ### Docker
-**/Dockerfile
-**/docker-compose*.yml
 docker-compose.override.yml
 docker-compose.local.yml
 

--- a/README.md
+++ b/README.md
@@ -32,3 +32,24 @@ Prerequisites
 - A GitHub account (to use Copilot and push to the remote)
 - Node.js (LTS recommended)
 - Docker & Docker Compose (for local container workflows)
+
+Backend (Nest.js)
+----------------
+
+The backend lives in `services/backend`.
+
+Run with Docker (image)
+~~~~~~~~~~~~~~~~~~~~~~
+
+- Build: `docker build -t demo-ai-native-sdlc-backend:local ./services/backend`
+- Run: `docker run --rm -p 3000:3000 -e APP_ENV=local -e APP_NAME=demo-ai-native-sdlc-backend demo-ai-native-sdlc-backend:local`
+
+Run with Docker Compose
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Start: `docker compose up --build`
+
+Check locally
+~~~~~~~~~~~~~
+
+- Health endpoint: http://localhost:3000/health

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  backend:
+    build:
+      context: ./services/backend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      PORT: "3000"
+      APP_NAME: "demo-ai-native-sdlc-backend"
+      APP_ENV: "local"
+      NODE_ENV: "production"

--- a/services/backend/.dockerignore
+++ b/services/backend/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+npm-debug.log
+dist
+.git
+.vscode
+.DS_Store
+
+# local env files
+.env
+.env.*

--- a/services/backend/.gitignore
+++ b/services/backend/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+.env
+.env.*

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm install --no-audit --no-fund
+
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:22-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev --no-audit --no-fund && npm cache clean --force
+COPY --from=build /app/dist ./dist
+EXPOSE 3000
+CMD ["node", "dist/main.js"]

--- a/services/backend/README.md
+++ b/services/backend/README.md
@@ -1,0 +1,7 @@
+# Backend (Nest.js)
+
+Minimal Nest.js REST API for demo-ai-native-sdlc.
+
+## Endpoints
+
+- `GET /health` → returns JSON with application name, environment, Nest.js version, Node.js version.

--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "demo-ai-native-sdlc-backend",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Nest.js backend API for demo-ai-native-sdlc",
+  "license": "UNLICENSED",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prestart": "npm run build",
+    "start": "node dist/main.js",
+    "start:dev": "ts-node --transpile-only src/main.ts",
+    "lint": "echo 'lint not configured'",
+    "test": "echo 'tests not configured'"
+  },
+  "dependencies": {
+    "@nestjs/common": "^10.4.15",
+    "@nestjs/core": "^10.4.15",
+    "@nestjs/platform-express": "^10.4.15",
+    "class-transformer": "^0.5.1",
+    "class-validator": "^0.14.1",
+    "reflect-metadata": "^0.2.2",
+    "rxjs": "^7.8.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^22.10.7",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.7.3"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/services/backend/src/app.module.ts
+++ b/services/backend/src/app.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+
+import { HealthModule } from './health/health.module';
+
+@Module({
+  imports: [HealthModule],
+})
+export class AppModule {}

--- a/services/backend/src/health/health.controller.ts
+++ b/services/backend/src/health/health.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+
+import { HealthService } from './health.service';
+
+@Controller('health')
+export class HealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get()
+  getHealth() {
+    return this.healthService.getHealth();
+  }
+}

--- a/services/backend/src/health/health.module.ts
+++ b/services/backend/src/health/health.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { HealthController } from './health.controller';
+import { HealthService } from './health.service';
+
+@Module({
+  controllers: [HealthController],
+  providers: [HealthService],
+})
+export class HealthModule {}

--- a/services/backend/src/health/health.service.ts
+++ b/services/backend/src/health/health.service.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+
+type HealthResponse = {
+  name: string;
+  environment: string;
+  nestVersion: string;
+  nodeVersion: string;
+};
+
+@Injectable()
+export class HealthService {
+  getHealth(): HealthResponse {
+    const environment =
+      process.env.APP_ENV ?? process.env.NODE_ENV ?? 'development';
+
+    const nestVersion = this.getNestVersion();
+
+    return {
+      name: process.env.APP_NAME ?? 'demo-ai-native-sdlc-backend',
+      environment,
+      nestVersion,
+      nodeVersion: process.version,
+    };
+  }
+
+  private getNestVersion(): string {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const pkg = require('@nestjs/core/package.json');
+      return typeof pkg?.version === 'string' ? pkg.version : 'unknown';
+    } catch {
+      return 'unknown';
+    }
+  }
+}

--- a/services/backend/src/main.ts
+++ b/services/backend/src/main.ts
@@ -1,0 +1,39 @@
+import 'reflect-metadata';
+import { Logger, ValidationPipe } from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+
+import { AppModule } from './app.module';
+import { HttpExceptionFilter } from './shared/http-exception.filter';
+import { requestLoggerMiddleware } from './shared/request-logger.middleware';
+
+async function bootstrap() {
+  const appName = process.env.APP_NAME ?? 'demo-ai-native-sdlc-backend';
+  const logger = new Logger(appName);
+
+  const app = await NestFactory.create(AppModule, {
+    logger,
+  });
+
+  app.use(requestLoggerMiddleware(logger));
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      transform: true,
+      whitelist: true,
+      forbidUnknownValues: true,
+    }),
+  );
+
+  app.useGlobalFilters(new HttpExceptionFilter(logger));
+
+  const port = Number(process.env.PORT ?? 3000);
+  await app.listen(port, '0.0.0.0');
+
+  logger.log(`Listening on http://0.0.0.0:${port}`);
+}
+
+bootstrap().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error('Fatal bootstrap error', err);
+  process.exitCode = 1;
+});

--- a/services/backend/src/shared/http-exception.filter.ts
+++ b/services/backend/src/shared/http-exception.filter.ts
@@ -1,0 +1,59 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  LoggerService,
+} from '@nestjs/common';
+import type { Request, Response } from 'express';
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  constructor(private readonly logger: LoggerService) {}
+
+  catch(exception: unknown, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    let status = HttpStatus.INTERNAL_SERVER_ERROR;
+    let errorResponse: unknown = { message: 'Internal Server Error' };
+
+    const exceptionAny = exception as any;
+    const isHttpExceptionLike =
+      exception instanceof HttpException ||
+      (exceptionAny &&
+        typeof exceptionAny.getStatus === 'function' &&
+        typeof exceptionAny.getResponse === 'function');
+
+    if (isHttpExceptionLike) {
+      status = Number(exceptionAny.getStatus());
+      errorResponse = exceptionAny.getResponse();
+    }
+
+    const message =
+      typeof errorResponse === 'string'
+        ? errorResponse
+        : (errorResponse as any)?.message ?? 'Error';
+
+    if (status >= 500) {
+      this.logger.error(
+        `${request.method} ${request.url} -> ${status} (${String(message)})`,
+        (exception as any)?.stack,
+      );
+    } else {
+      this.logger.warn(
+        `${request.method} ${request.url} -> ${status} (${String(message)})`,
+      );
+    }
+
+    response.status(status).json({
+      statusCode: status,
+      path: request.url,
+      method: request.method,
+      timestamp: new Date().toISOString(),
+      message,
+    });
+  }
+}

--- a/services/backend/src/shared/request-logger.middleware.ts
+++ b/services/backend/src/shared/request-logger.middleware.ts
@@ -1,0 +1,17 @@
+import type { NextFunction, Request, Response } from 'express';
+import type { LoggerService } from '@nestjs/common';
+
+export function requestLoggerMiddleware(logger: LoggerService) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const start = process.hrtime.bigint();
+
+    res.on('finish', () => {
+      const durationMs = Number(process.hrtime.bigint() - start) / 1_000_000;
+      logger.log(
+        `${req.method} ${req.originalUrl} -> ${res.statusCode} (${durationMs.toFixed(1)}ms)`,
+      );
+    });
+
+    next();
+  };
+}

--- a/services/backend/tsconfig.build.json
+++ b/services/backend/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/services/backend/tsconfig.json
+++ b/services/backend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "declaration": false,
+    "removeComments": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "target": "ES2022",
+    "sourceMap": true,
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "incremental": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "strict": true,
+    "noImplicitAny": false
+  }
+}


### PR DESCRIPTION
Closes #9 (sub-task of #4).

Adds a minimal Nest.js backend in `services/backend` with:
- `GET /health` returning app name/env + Nest/Node versions
- Request logging middleware
- Global exception filter for JSON error responses
- Multi-stage Dockerfile + root docker-compose.yml

Run locally:
- `docker compose up --build`
- Visit http://localhost:3000/health
