### PR TITLE
feat: model-driven list-types/list-elements

### DIFF
--- a/services/backend/src/diagrams/mermaid/mermaid-generator.service.ts
+++ b/services/backend/src/diagrams/mermaid/mermaid-generator.service.ts
@@ -49,7 +49,13 @@ export class MermaidGeneratorService {
     const nl = mapping.globals?.line_separator ?? '\n';
 
     const mermaidId = this.applyTemplate(entityCfg.mermaid.id, { object });
-    const label = this.applyTemplate(entityCfg.mermaid.label, { object });
+    const labelTemplate =
+      typeof (entityCfg as any)?.mermaid?.label === 'string'
+        ? (entityCfg as any).mermaid.label
+        : typeof (entityCfg as any)?.label === 'string'
+          ? (entityCfg as any).label
+          : '{{ object.name }}';
+    const label = this.applyTemplate(labelTemplate, { object });
 
     const anchorStart = this.anchorStart(mermaidId);
     const anchorEnd = this.anchorEnd(mermaidId);


### PR DESCRIPTION
Implements model-driven hierarchy for Add/Move menus.

Changes
- Backend: list-types filtered by parent context per services/backend/config/netbox-model.yaml; deterministic sorting; no duplicates.
- Backend: list-elements now lists candidate parent targets for the current element type (includes allowed roots, excludes self and descendants).
- Frontend: menu payloads now send the selected context for Add/Move and render backend-provided root targets.
- Fix: unblock create/move by reading Mermaid entity label from mapping correctly.

Closes #26
Refs #23
