### PR TITLE
feat(csv): ordered NetBox types by category (criterion 1)

### DIFF
--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/main.js",
     "start:dev": "ts-node --transpile-only src/main.ts",
     "lint": "echo 'lint not configured'",
-    "test": "echo 'tests not configured'"
+    "test": "ts-node --transpile-only test/netbox-model-analysis.test.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.15",

--- a/services/backend/src/csv/csv.controller.ts
+++ b/services/backend/src/csv/csv.controller.ts
@@ -7,6 +7,7 @@ import {
   Get,
   Logger,
   Param,
+  Query,
   Res,
 } from '@nestjs/common';
 import {
@@ -14,10 +15,11 @@ import {
   ApiNotFoundResponse,
   ApiOkResponse,
   ApiProduces,
+  ApiQuery,
   ApiTags,
 } from '@nestjs/swagger';
 
-import { CsvTypesResponse } from './models/csv.models';
+import { CsvOrderedTypesResponse } from './models/csv.models';
 import { CsvService } from './csv.service';
 
 function sanitizeFilenamePart(input: string): string {
@@ -92,11 +94,20 @@ export class CsvController {
   }
 
   @Get(':diagramId')
-  @ApiOkResponse({ type: CsvTypesResponse })
+  @ApiQuery({
+    name: 'category',
+    required: true,
+    description: 'Type category derived from NetBox model roots (e.g. Definitions, Infrastructure)',
+    example: 'Definitions',
+  })
+  @ApiOkResponse({ type: CsvOrderedTypesResponse })
   @ApiBadRequestResponse({ description: 'Invalid diagram id or generator output' })
   @ApiNotFoundResponse({ description: 'Diagram not found' })
-  async list(@Param('diagramId') diagramId: string): Promise<CsvTypesResponse> {
-    return this.csvService.listTypes(diagramId);
+  async list(
+    @Param('diagramId') diagramId: string,
+    @Query('category') category?: string,
+  ): Promise<CsvOrderedTypesResponse> {
+    return this.csvService.listOrderedTypes(diagramId, category);
   }
 
   @Get(':diagramId/:type')

--- a/services/backend/src/csv/csv.module.ts
+++ b/services/backend/src/csv/csv.module.ts
@@ -1,13 +1,14 @@
 import { Module } from '@nestjs/common';
 
 import { DiagramsModule } from '../diagrams/diagrams.module';
+import { NetboxConfigModule } from '../netbox-config/netbox-config.module';
 import { CsvController } from './csv.controller';
 import { CSV_DATASET_GENERATOR } from './csv.generator';
 import { CsvService } from './csv.service';
 import { MockCsvDatasetGenerator } from './mock-csv.generator';
 
 @Module({
-  imports: [DiagramsModule],
+  imports: [DiagramsModule, NetboxConfigModule],
   controllers: [CsvController],
   providers: [
     CsvService,

--- a/services/backend/src/csv/models/csv.models.ts
+++ b/services/backend/src/csv/models/csv.models.ts
@@ -34,3 +34,19 @@ export class CsvTypesResponse {
   })
   types!: string[];
 }
+
+export class CsvOrderedTypesResponse {
+  @ApiProperty({ example: 'hcqOn88HKnyHcHE6' })
+  diagramId!: string;
+
+  @ApiProperty({ example: 'Definitions', description: 'Requested type category' })
+  category!: string;
+
+  @ApiProperty({
+    description: 'Ordered NetBox entity types for the category and diagram',
+    example: ['tenant-group', 'tenant', 'site-group'],
+    isArray: true,
+    type: String,
+  })
+  types!: string[];
+}

--- a/services/backend/src/diagrams/diagrams.module.ts
+++ b/services/backend/src/diagrams/diagrams.module.ts
@@ -13,6 +13,6 @@ import { MermaidGeneratorService } from './mermaid/mermaid-generator.service';
   imports: [NetboxConfigModule],
   controllers: [DiagramsController, DiagramsCommandsController],
   providers: [DiagramsService, MermaidGeneratorService, DiagramDomainStore, DiagramsCommandsService],
-  exports: [DiagramsService],
+  exports: [DiagramsService, DiagramDomainStore],
 })
 export class DiagramsModule {}

--- a/services/backend/src/health/health-api.controller.ts
+++ b/services/backend/src/health/health-api.controller.ts
@@ -1,0 +1,13 @@
+import { Controller, Get } from '@nestjs/common';
+
+import { HealthService } from './health.service';
+
+@Controller('api/health')
+export class ApiHealthController {
+  constructor(private readonly healthService: HealthService) {}
+
+  @Get()
+  getHealth() {
+    return this.healthService.getHealth();
+  }
+}

--- a/services/backend/src/health/health.module.ts
+++ b/services/backend/src/health/health.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 
+import { ApiHealthController } from './health-api.controller';
 import { HealthController } from './health.controller';
 import { HealthService } from './health.service';
 
 @Module({
-  controllers: [HealthController],
+  controllers: [HealthController, ApiHealthController],
   providers: [HealthService],
 })
 export class HealthModule {}

--- a/services/backend/src/netbox-config/netbox-config.module.ts
+++ b/services/backend/src/netbox-config/netbox-config.module.ts
@@ -3,6 +3,7 @@ import { Module } from '@nestjs/common';
 import { MermaidStylesService } from './mermaid-styles.service';
 import { NetboxConfigService } from './netbox-config.service';
 import { NetboxModelService } from './netbox-model.service';
+import { NetboxModelAnalysisService } from './netbox-model-analysis.service';
 import { NetboxToMermaidService } from './netbox-to-mermaid.service';
 
 @Module({
@@ -11,7 +12,8 @@ import { NetboxToMermaidService } from './netbox-to-mermaid.service';
     NetboxModelService,
     NetboxToMermaidService,
     MermaidStylesService,
+    NetboxModelAnalysisService,
   ],
-  exports: [NetboxModelService, NetboxToMermaidService, MermaidStylesService],
+  exports: [NetboxModelService, NetboxToMermaidService, MermaidStylesService, NetboxModelAnalysisService],
 })
 export class NetboxConfigModule {}

--- a/services/backend/src/netbox-config/netbox-model-analysis.service.ts
+++ b/services/backend/src/netbox-config/netbox-model-analysis.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+
+import type { NetboxModelConfig } from './netbox-config.models';
+import { NetboxModelService } from './netbox-model.service';
+import {
+  analyzeModelByRoot,
+  closureWithDependencies,
+  normalizeCategoryInput,
+  titleCaseCategory,
+  type CategoryAnalysis,
+} from './netbox-model-analysis';
+
+export type CsvCategory = {
+  rootKey: string;
+  name: string;
+};
+
+@Injectable()
+export class NetboxModelAnalysisService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(NetboxModelAnalysisService.name);
+
+  private model!: NetboxModelConfig;
+  private analysesByRootKey: Record<string, CategoryAnalysis> = {};
+  private categories: CsvCategory[] = [];
+
+  constructor(private readonly modelService: NetboxModelService) {}
+
+  onApplicationBootstrap(): void {
+    this.model = this.modelService.get();
+
+    this.analysesByRootKey = analyzeModelByRoot(this.model);
+
+    this.categories = Object.keys(this.analysesByRootKey)
+      .sort((a, b) => a.localeCompare(b))
+      .map((rootKey) => ({ rootKey, name: titleCaseCategory(rootKey) }));
+
+    const summary = this.categories
+      .map((c) => `${c.name}=${this.analysesByRootKey[c.rootKey].ordered.length}`)
+      .join(', ');
+
+    this.logger.log(
+      `NetBox model analysis ready (categories: ${this.categories.length}; ${summary})`,
+    );
+  }
+
+  getAllowedCategories(): string[] {
+    return this.categories.map((c) => c.name);
+  }
+
+  getCategoryNameForRoot(rootKey: string): string {
+    const found = this.categories.find((c) => c.rootKey === rootKey);
+    return found?.name ?? titleCaseCategory(rootKey);
+  }
+
+  /**
+   * Converts API category input (e.g. 'Definitions') to a root key (e.g. 'definitions').
+   */
+  resolveRootKeyFromCategory(category: string): string | null {
+    const norm = normalizeCategoryInput(category);
+
+    // Allow both TitleCase and raw root keys.
+    for (const c of this.categories) {
+      if (norm === normalizeCategoryInput(c.name) || norm === normalizeCategoryInput(c.rootKey)) {
+        return c.rootKey;
+      }
+    }
+
+    return null;
+  }
+
+  getOrderedTypesForRoot(rootKey: string): string[] {
+    const a = this.analysesByRootKey[rootKey];
+    if (!a) throw new Error(`Unknown rootKey '${rootKey}'`);
+    return a.ordered.slice();
+  }
+
+  getAnalysisForRoot(rootKey: string): CategoryAnalysis {
+    const a = this.analysesByRootKey[rootKey];
+    if (!a) throw new Error(`Unknown rootKey '${rootKey}'`);
+    return a;
+  }
+
+  getNeededTypesForRoot(rootKey: string, seedTypes: Iterable<string>): Set<string> {
+    const analysis = this.getAnalysisForRoot(rootKey);
+    return closureWithDependencies(analysis, seedTypes);
+  }
+}

--- a/services/backend/src/netbox-config/netbox-model-analysis.ts
+++ b/services/backend/src/netbox-config/netbox-model-analysis.ts
@@ -1,0 +1,239 @@
+import type { NetboxModelConfig } from './netbox-config.models';
+
+export type NetboxRootKey = string;
+
+export type CategoryAnalysis = {
+  rootKey: NetboxRootKey;
+  nodes: string[];
+  ordered: string[];
+  // dependent -> sorted list of dependencies (subset of `nodes`)
+  dependencies: Record<string, string[]>;
+};
+
+export function titleCaseCategory(rootKey: string): string {
+  // Minimal, stable formatting for API categories.
+  const words = rootKey
+    .replace(/[_-]+/g, ' ')
+    .split(' ')
+    .filter(Boolean)
+    .map((w) => w.slice(0, 1).toUpperCase() + w.slice(1));
+  return words.join(' ');
+}
+
+export function normalizeCategoryInput(input: string): string {
+  return input.trim().toLowerCase();
+}
+
+export function computeEntityRoots(model: NetboxModelConfig): Record<string, Set<string>> {
+  const entities = model.entities ?? {};
+
+  const rootsByEntity: Record<string, Set<string>> = {};
+  for (const entity of Object.keys(entities)) {
+    rootsByEntity[entity] = new Set<string>();
+    const allowed = entities[entity]?.parent?.allowed ?? [];
+    for (const a of allowed) {
+      if (a && typeof (a as any).root === 'string') {
+        rootsByEntity[entity].add(String((a as any).root));
+      }
+    }
+  }
+
+  // Propagate roots through parent-entity links until fixpoint.
+  // If A can be under parent entity P, then A can also be under any root that P can.
+  let changed = true;
+  const maxPasses = Math.max(1, Object.keys(entities).length + 5);
+  let passes = 0;
+
+  while (changed) {
+    if (passes++ > maxPasses) {
+      // Should never happen, but prevents infinite loops in malformed configs.
+      throw new Error('NetBox model root propagation exceeded safety limit (possible cycle)');
+    }
+
+    changed = false;
+    for (const entity of Object.keys(entities)) {
+      const allowed = entities[entity]?.parent?.allowed ?? [];
+      for (const a of allowed) {
+        const parentEntity = (a as any)?.entity;
+        if (typeof parentEntity !== 'string' || !parentEntity) continue;
+        const parentRoots = rootsByEntity[parentEntity];
+        if (!parentRoots) continue;
+        const childRoots = rootsByEntity[entity];
+        const before = childRoots.size;
+        for (const r of parentRoots) childRoots.add(r);
+        if (childRoots.size !== before) changed = true;
+      }
+    }
+  }
+
+  return rootsByEntity;
+}
+
+export type DependencyEdge = { from: string; to: string };
+
+export function buildCategoryDependencyEdges(model: NetboxModelConfig, nodes: Set<string>): DependencyEdge[] {
+  const entities = model.entities ?? {};
+  const edges: DependencyEdge[] = [];
+
+  // Parent dependencies: parent entity must exist before child.
+  for (const [entity, cfg] of Object.entries(entities)) {
+    if (!nodes.has(entity)) continue;
+    const allowed = cfg?.parent?.allowed ?? [];
+    for (const a of allowed) {
+      const parentEntity = (a as any)?.entity;
+      if (typeof parentEntity !== 'string' || !parentEntity) continue;
+      if (parentEntity === entity) continue;
+      if (!nodes.has(parentEntity)) continue;
+      edges.push({ from: parentEntity, to: entity });
+    }
+  }
+
+  // Link dependencies: link target entity should exist before current entity.
+  for (const [entity, cfg] of Object.entries(entities)) {
+    if (!nodes.has(entity)) continue;
+    const links = cfg?.links ?? {};
+    for (const link of Object.values(links)) {
+      const dep = (link as any)?.entity;
+      if (typeof dep !== 'string' || !dep) continue;
+      if (dep === entity) continue;
+      if (!nodes.has(dep)) continue;
+      edges.push({ from: dep, to: entity });
+    }
+  }
+
+  // De-duplicate edges for deterministic behavior.
+  const dedup = new Map<string, DependencyEdge>();
+  for (const e of edges) {
+    dedup.set(`${e.from}→${e.to}`, e);
+  }
+
+  return Array.from(dedup.values()).sort((a, b) => {
+    const f = a.from.localeCompare(b.from);
+    if (f) return f;
+    return a.to.localeCompare(b.to);
+  });
+}
+
+export function topoSortDeterministic(nodes: string[], edges: DependencyEdge[]): { ordered: string[]; cycleNodes: string[] } {
+  const nodeSet = new Set(nodes);
+  const indegree = new Map<string, number>();
+  const outgoing = new Map<string, Set<string>>();
+
+  for (const n of nodes) {
+    indegree.set(n, 0);
+    outgoing.set(n, new Set());
+  }
+
+  for (const e of edges) {
+    if (!nodeSet.has(e.from) || !nodeSet.has(e.to)) continue;
+    const out = outgoing.get(e.from)!;
+    if (out.has(e.to)) continue;
+    out.add(e.to);
+    indegree.set(e.to, (indegree.get(e.to) ?? 0) + 1);
+  }
+
+  const ready: string[] = nodes.filter((n) => (indegree.get(n) ?? 0) === 0).sort((a, b) => a.localeCompare(b));
+
+  const ordered: string[] = [];
+  while (ready.length) {
+    // Always pick the lexicographically smallest available node.
+    const n = ready.shift()!;
+    ordered.push(n);
+
+    const outs = Array.from(outgoing.get(n) ?? []).sort((a, b) => a.localeCompare(b));
+    for (const m of outs) {
+      indegree.set(m, (indegree.get(m) ?? 0) - 1);
+      if ((indegree.get(m) ?? 0) === 0) {
+        // Insert while keeping `ready` sorted for deterministic output.
+        const idx = lowerBound(ready, m);
+        ready.splice(idx, 0, m);
+      }
+    }
+  }
+
+  if (ordered.length !== nodes.length) {
+    const cycleNodes = nodes.filter((n) => (indegree.get(n) ?? 0) > 0).sort((a, b) => a.localeCompare(b));
+    return { ordered: [], cycleNodes };
+  }
+
+  return { ordered, cycleNodes: [] };
+}
+
+function lowerBound(sorted: string[], value: string): number {
+  let lo = 0;
+  let hi = sorted.length;
+  while (lo < hi) {
+    const mid = (lo + hi) >> 1;
+    if (sorted[mid].localeCompare(value) < 0) lo = mid + 1;
+    else hi = mid;
+  }
+  return lo;
+}
+
+export function analyzeModelByRoot(model: NetboxModelConfig): Record<string, CategoryAnalysis> {
+  const rootsByEntity = computeEntityRoots(model);
+  const rootKeys = Object.keys(model.roots ?? {}).sort((a, b) => a.localeCompare(b));
+
+  const result: Record<string, CategoryAnalysis> = {};
+
+  for (const rootKey of rootKeys) {
+    const nodes = Object.keys(model.entities ?? {})
+      .filter((entity) => rootsByEntity[entity]?.has(rootKey))
+      .sort((a, b) => a.localeCompare(b));
+
+    const nodeSet = new Set(nodes);
+    const edges = buildCategoryDependencyEdges(model, nodeSet);
+
+    const { ordered, cycleNodes } = topoSortDeterministic(nodes, edges);
+    if (cycleNodes.length) {
+      throw new Error(
+        `NetBox model dependency cycle detected for root '${rootKey}': ${cycleNodes.join(', ')}`,
+      );
+    }
+
+    const deps: Record<string, Set<string>> = {};
+    for (const n of nodes) deps[n] = new Set<string>();
+    for (const e of edges) {
+      deps[e.to]?.add(e.from);
+    }
+
+    result[rootKey] = {
+      rootKey,
+      nodes,
+      ordered,
+      dependencies: Object.fromEntries(
+        Object.entries(deps)
+          .map(([k, v]) => [k, Array.from(v).sort((a, b) => a.localeCompare(b))]),
+      ),
+    };
+  }
+
+  return result;
+}
+
+export function closureWithDependencies(analysis: CategoryAnalysis, seedTypes: Iterable<string>): Set<string> {
+  const needed = new Set<string>();
+  const stack: string[] = [];
+
+  for (const t of seedTypes) {
+    if (!t) continue;
+    if (!analysis.dependencies[t] && !analysis.nodes.includes(t)) continue;
+    if (!needed.has(t)) {
+      needed.add(t);
+      stack.push(t);
+    }
+  }
+
+  while (stack.length) {
+    const cur = stack.pop()!;
+    const deps = analysis.dependencies[cur] ?? [];
+    for (const d of deps) {
+      if (!needed.has(d)) {
+        needed.add(d);
+        stack.push(d);
+      }
+    }
+  }
+
+  return needed;
+}

--- a/services/backend/test/netbox-model-analysis.test.ts
+++ b/services/backend/test/netbox-model-analysis.test.ts
@@ -1,0 +1,101 @@
+import * as assert from 'node:assert/strict';
+
+import type { NetboxModelConfig } from '../src/netbox-config/netbox-config.models';
+import {
+  analyzeModelByRoot,
+  closureWithDependencies,
+  topoSortDeterministic,
+} from '../src/netbox-config/netbox-model-analysis';
+
+function modelFixture(): NetboxModelConfig {
+  return {
+    version: 1,
+    roots: {
+      definitions: { description: 'Definitions' },
+      infrastructure: { description: 'Infrastructure' },
+    },
+    entities: {
+      // defs
+      tenant: {
+        parent: { allowed: [{ root: 'definitions' }] },
+        links: {},
+        attributes: {},
+      },
+      // infra chain: region -> site -> rack
+      region: {
+        parent: { allowed: [{ root: 'infrastructure' }] },
+        links: {},
+        attributes: {},
+      },
+      site: {
+        parent: { allowed: [{ entity: 'region' }] },
+        links: { tenant: { entity: 'tenant', field: 'tenant' } },
+        attributes: {},
+      },
+      rack: {
+        parent: { allowed: [{ entity: 'site' }] },
+        links: {},
+        attributes: {},
+      },
+      // independent infra node to test tie-breaking
+      vlan: {
+        parent: { allowed: [{ root: 'infrastructure' }] },
+        links: {},
+        attributes: {},
+      },
+    },
+  };
+}
+
+// Basic deterministic topo behavior
+{
+  const { ordered, cycleNodes } = topoSortDeterministic(
+    ['b', 'a', 'c'],
+    [{ from: 'a', to: 'c' }],
+  );
+  assert.deepEqual(cycleNodes, []);
+  assert.deepEqual(ordered, ['a', 'b', 'c']);
+}
+
+// Model analysis by roots
+{
+  const model = modelFixture();
+  const analyses = analyzeModelByRoot(model);
+
+  assert.ok(analyses.definitions);
+  assert.ok(analyses.infrastructure);
+
+  // definitions contains tenant only
+  assert.deepEqual(analyses.definitions.ordered, ['tenant']);
+
+  // infrastructure contains region/site/rack/vlan and orders dependencies correctly.
+  const ordered = analyses.infrastructure.ordered;
+  assert.ok(ordered.indexOf('region') < ordered.indexOf('site'));
+  assert.ok(ordered.indexOf('site') < ordered.indexOf('rack'));
+
+  // stable ordering for independent nodes (region vs vlan) comes from lexicographic tie-breaker.
+  assert.ok(ordered.indexOf('region') < ordered.indexOf('vlan'));
+
+  // closure includes dependencies
+  const needed = closureWithDependencies(analyses.infrastructure, ['rack']);
+  assert.equal(needed.has('rack'), true);
+  assert.equal(needed.has('site'), true);
+  assert.equal(needed.has('region'), true);
+}
+
+// Cycle detection
+{
+  const model = modelFixture();
+  model.entities.a = {
+    parent: { allowed: [{ root: 'infrastructure' }] },
+    links: { b: { entity: 'b', field: 'b' } },
+  } as any;
+  model.entities.b = {
+    parent: { allowed: [{ root: 'infrastructure' }] },
+    links: { a: { entity: 'a', field: 'a' } },
+  } as any;
+
+  assert.throws(() => analyzeModelByRoot(model), /cycle detected/i);
+}
+
+console.log('netbox-model-analysis.test.ts: OK');


### PR DESCRIPTION
Fixes #28

### What
- `GET /api/csv/:diagramId?category=...` returns an ordered list of NetBox entity **types only** for the requested category
- Order is computed once at startup from `netbox-model.yaml` using dependency graph + deterministic topological sort
- Response is diagram-aware: filters to types present in the diagram domain state (plus intra-category dependencies)

### Validation (Docker-only)
- `docker compose up --build -d`
- `curl http://localhost:3000/api/health`
- `curl "http://localhost:3000/api/csv/<diagramId>?category=Definitions"`
- `curl "http://localhost:3000/api/csv/<diagramId>?category=Infrastructure"`

### Tests (Docker-only)
- `docker build -t demo-ai-native-sdlc-backend-build --target build services/backend`
- `docker run --rm demo-ai-native-sdlc-backend-build npm test`
