### PR TITLE
feat: add CSV download menu

### DIFF
--- a/services/frontend/lib/backend.ts
+++ b/services/frontend/lib/backend.ts
@@ -15,3 +15,37 @@ export async function backendFetch(path: string, init?: RequestInit): Promise<Re
     },
   });
 }
+
+/**
+ * Fetches an API path in a way that works in both server and browser contexts.
+ *
+ * - Server: calls the backend directly via NEXT_PUBLIC_API_BASE_URL (docker: http://backend:3000)
+ * - Browser: calls the Next.js `/api/*` rewrite (host-relative)
+ */
+export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+  if (typeof window !== 'undefined') {
+    return fetch(path, {
+      cache: 'no-store',
+      ...init,
+    });
+  }
+
+  // Server-side: keep existing behavior.
+  return backendFetch(path, init);
+}
+
+export async function apiFetchJson<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await apiFetch(path, {
+    ...init,
+    headers: {
+      accept: 'application/json',
+      ...(init?.headers ?? {}),
+    },
+  });
+
+  if (!res.ok) {
+    throw new Error(`Request failed (${res.status})`);
+  }
+
+  return (await res.json()) as T;
+}

--- a/services/frontend/lib/download.ts
+++ b/services/frontend/lib/download.ts
@@ -1,0 +1,50 @@
+export function slugifyFilenamePart(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+export function safeFilename(value: string, fallback: string): string {
+  const cleaned = value.replace(/[^0-9a-zA-Z _.-]+/g, '_').trim();
+  return cleaned.length ? cleaned : fallback;
+}
+
+export function parseContentDispositionFilename(header: string | null): string | null {
+  if (!header) return null;
+
+  // Minimal MVP parsing for: attachment; filename="foo.csv"
+  // (We intentionally ignore RFC 5987 filename*= for simplicity.)
+  const m = header.match(/filename="?([^";]+)"?/i);
+  if (!m) return null;
+
+  const candidate = m[1]?.trim();
+  return candidate ? candidate : null;
+}
+
+export async function downloadViaFetch(url: string, fallbackFilename: string): Promise<void> {
+  const res = await fetch(url, { method: 'GET' });
+  if (!res.ok) {
+    throw new Error(`Download failed (${res.status})`);
+  }
+
+  const headerFilename = parseContentDispositionFilename(res.headers.get('content-disposition'));
+  const filename = safeFilename(headerFilename ?? fallbackFilename, 'download');
+
+  const blob = await res.blob();
+  const objectUrl = URL.createObjectURL(blob);
+
+  try {
+    const a = document.createElement('a');
+    a.href = objectUrl;
+    a.download = filename;
+    a.rel = 'noopener';
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+  } finally {
+    // Let the browser start the download before revoking.
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 0);
+  }
+}


### PR DESCRIPTION
Adds a Download submenu to the Diagram List ⋮ menu to export NetBox CSVs (ZIP + per-type by Definitions/Infrastructure).
Fixes #33