### PR TITLE
feat(backend): resolve critical tech debt

### DIFF
--- a/services/backend/README.md
+++ b/services/backend/README.md
@@ -2,6 +2,17 @@
 
 Minimal Nest.js REST API for demo-ai-native-sdlc.
 
+## Environment variables
+
+- `PORT` (default: `3000`)
+- `APP_NAME` / `APP_ENV` (used by health endpoints)
+- `DIAGRAMS_DIR` (default: `/app/diagrams`) — filesystem storage for Mermaid (`.mmd`) and domain state (`.domain.json`).
+- `SEED_SAMPLE_DIAGRAMS` (default: disabled) — when set to `true`, seeds sample diagrams on startup only if diagram storage is empty.
+- `NETBOX_CONFIG_DIR` (default: `<cwd>/config`) — directory containing YAML config:
+	- `netbox-model.yaml` (required)
+	- `netbox-to-mermaid.yaml` (required)
+	- `mermaid-styles.yaml` (optional; if missing, styling is skipped)
+
 ## Endpoints
 
 - `GET /health` → returns JSON with application name, environment, Nest.js version, Node.js version.

--- a/services/backend/package.json
+++ b/services/backend/package.json
@@ -11,7 +11,7 @@
     "start": "node dist/main.js",
     "start:dev": "ts-node --transpile-only src/main.ts",
     "lint": "echo 'lint not configured'",
-    "test": "ts-node --transpile-only test/netbox-model-analysis.test.ts && ts-node --transpile-only test/netbox-csv-generator.test.ts"
+    "test": "ts-node --transpile-only test/netbox-model-analysis.test.ts && ts-node --transpile-only test/netbox-csv-generator.test.ts && ts-node --transpile-only test/diagram-domain-store.test.ts"
   },
   "dependencies": {
     "@nestjs/common": "^10.4.15",

--- a/services/backend/src/csv/csv.generator.ts
+++ b/services/backend/src/csv/csv.generator.ts
@@ -1,6 +1,6 @@
 import type { CsvDataset } from './models/csv.models';
 
-export const CSV_DATASET_GENERATOR = 'CSV_DATASET_GENERATOR';
+export const CSV_DATASET_GENERATOR = Symbol('CSV_DATASET_GENERATOR');
 
 export interface CsvDatasetGenerator {
   generate(input: {

--- a/services/backend/src/diagrams/diagrams.service.ts
+++ b/services/backend/src/diagrams/diagrams.service.ts
@@ -49,10 +49,33 @@ export class DiagramsService implements OnModuleInit {
     await ensureDir(this.diagramsDir);
     await this.loadIndex();
 
-    // Seed sample diagrams if empty
-    if (this.metadataById.size === 0) {
-      await this.seedSampleDiagrams();
+    const seedEnabled = String(process.env.SEED_SAMPLE_DIAGRAMS ?? '')
+      .trim()
+      .toLowerCase() === 'true';
+
+    // Seed sample diagrams only when explicitly enabled.
+    if (!seedEnabled) {
+      if (this.metadataById.size === 0) {
+        this.logger.log(
+          `Sample diagram seeding is disabled (set SEED_SAMPLE_DIAGRAMS=true to enable). Storage is empty; continuing without seeding.`,
+        );
+      } else {
+        this.logger.log(`Sample diagram seeding is disabled (SEED_SAMPLE_DIAGRAMS!=true).`);
+      }
+      return;
     }
+
+    if (this.metadataById.size > 0) {
+      this.logger.log(
+        `Sample diagram seeding is enabled (SEED_SAMPLE_DIAGRAMS=true) but storage is not empty; skipping seeding.`,
+      );
+      return;
+    }
+
+    this.logger.log(
+      `Sample diagram seeding is enabled (SEED_SAMPLE_DIAGRAMS=true) and storage is empty; seeding now.`,
+    );
+    await this.seedSampleDiagrams();
   }
 
   private async seedSampleDiagrams(): Promise<void> {

--- a/services/backend/src/netbox-config/netbox-config.service.ts
+++ b/services/backend/src/netbox-config/netbox-config.service.ts
@@ -25,19 +25,29 @@ export class NetboxConfigService implements OnModuleInit {
     const stylesPath = path.join(configDir, 'mermaid-styles.yaml');
 
     this.logger.log(`Loading NetBox YAML config from ${configDir}`);
+    this.logger.log(
+      `NetBox config files: model=${modelPath}, mapping=${mappingPath}, styles=${stylesPath} (optional)`,
+    );
 
     const [modelRaw, mappingRaw, stylesRaw] = await Promise.all([
-      fs.readFile(modelPath, 'utf8'),
-      fs.readFile(mappingPath, 'utf8'),
-      fs.readFile(stylesPath, 'utf8'),
+      this.readTextFile(modelPath, { required: true }),
+      this.readTextFile(mappingPath, { required: true }),
+      this.readTextFile(stylesPath, { required: false }),
     ]);
 
-    const model = yaml.load(modelRaw) as NetboxModelConfig;
-    const mapping = yaml.load(mappingRaw) as NetboxToMermaidConfig;
-    const styles = yaml.load(stylesRaw) as MermaidStylesConfig;
+    const model = this.parseYaml<NetboxModelConfig>(modelRaw, modelPath);
+    const mapping = this.parseYaml<NetboxToMermaidConfig>(mappingRaw, mappingPath);
+    const styles = stylesRaw
+      ? this.parseYaml<MermaidStylesConfig>(stylesRaw, stylesPath)
+      : this.defaultStylesConfig();
 
-    if (!model?.entities || !mapping?.entities || !mapping?.roots) {
-      throw new Error('Invalid NetBox YAML config (missing required sections)');
+    this.validateModelConfig(model, modelPath);
+    this.validateMappingConfig(mapping, mappingPath);
+
+    if (stylesRaw) {
+      this.validateStylesConfig(styles, stylesPath);
+    } else {
+      this.logger.warn(`Mermaid styles config not found at ${stylesPath}; continuing without styles`);
     }
 
     this.loaded = { model, mapping, styles };
@@ -60,5 +70,90 @@ export class NetboxConfigService implements OnModuleInit {
   getStyles(): MermaidStylesConfig {
     if (!this.loaded) throw new Error('NetboxConfigService not initialized');
     return this.loaded.styles;
+  }
+
+  private async readTextFile(filePath: string, opts: { required: true }): Promise<string>;
+  private async readTextFile(filePath: string, opts: { required: false }): Promise<string | null>;
+  private async readTextFile(
+    filePath: string,
+    opts: { required: boolean },
+  ): Promise<string | null> {
+    try {
+      return await fs.readFile(filePath, 'utf8');
+    } catch (err) {
+      const code = (err as any)?.code;
+      if (!opts.required && code === 'ENOENT') {
+        return null;
+      }
+      const detail = code ? ` (${code})` : '';
+      throw new Error(`Failed to read NetBox config file at ${filePath}${detail}`);
+    }
+  }
+
+  private parseYaml<T>(raw: string, filePath: string): T {
+    try {
+      return yaml.load(raw) as T;
+    } catch (err) {
+      const msg = (err as any)?.message ? String((err as any).message) : String(err);
+      throw new Error(`Failed to parse YAML in ${filePath}: ${msg}`);
+    }
+  }
+
+  private isRecord(value: unknown): value is Record<string, any> {
+    return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  }
+
+  private validateModelConfig(model: NetboxModelConfig, filePath: string) {
+    if (!this.isRecord(model)) {
+      throw new Error(`Invalid NetBox model config: expected a YAML object in ${filePath}`);
+    }
+    if (!this.isRecord((model as any).entities)) {
+      throw new Error(
+        `Invalid NetBox model config: missing required section 'entities' in ${filePath}`,
+      );
+    }
+  }
+
+  private validateMappingConfig(mapping: NetboxToMermaidConfig, filePath: string) {
+    if (!this.isRecord(mapping)) {
+      throw new Error(`Invalid NetBox mapping config: expected a YAML object in ${filePath}`);
+    }
+    if (!this.isRecord((mapping as any).entities)) {
+      throw new Error(
+        `Invalid NetBox mapping config: missing required section 'entities' in ${filePath}`,
+      );
+    }
+    if (!this.isRecord((mapping as any).roots)) {
+      throw new Error(
+        `Invalid NetBox mapping config: missing required section 'roots' in ${filePath}`,
+      );
+    }
+  }
+
+  private validateStylesConfig(styles: MermaidStylesConfig, filePath: string) {
+    if (!this.isRecord(styles)) {
+      throw new Error(`Invalid Mermaid styles config: expected a YAML object in ${filePath}`);
+    }
+
+    // Styles are optional, but if present they should at least look like a config object.
+    if ((styles as any).version === undefined || (styles as any).kind === undefined) {
+      throw new Error(
+        `Invalid Mermaid styles config: expected 'version' and 'kind' in ${filePath}`,
+      );
+    }
+
+    if ((styles as any).themes !== undefined && !this.isRecord((styles as any).themes)) {
+      throw new Error(
+        `Invalid Mermaid styles config: 'themes' must be an object when present (${filePath})`,
+      );
+    }
+  }
+
+  private defaultStylesConfig(): MermaidStylesConfig {
+    return {
+      version: 1,
+      kind: 'mermaid-styles',
+      themes: {},
+    };
   }
 }

--- a/services/backend/test/diagram-domain-store.test.ts
+++ b/services/backend/test/diagram-domain-store.test.ts
@@ -1,0 +1,211 @@
+import * as assert from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { DiagramDomainStore } from '../src/diagrams/commands/diagram-domain.store';
+import { NetboxConfigService } from '../src/netbox-config/netbox-config.service';
+
+async function withTempDir(fn: (dir: string) => Promise<void>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'demo-ai-native-sdlc-'));
+  try {
+    await fn(dir);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function testDomainStoreRejectsInvalidParent() {
+  const prev = process.env.DIAGRAMS_DIR;
+
+  await withTempDir(async (dir) => {
+    process.env.DIAGRAMS_DIR = dir;
+
+    const diagramId = 'd1';
+    const filePath = path.join(dir, `${diagramId}.domain.json`);
+
+    await fs.writeFile(
+      filePath,
+      JSON.stringify(
+        {
+          version: 1,
+          objects: [
+            {
+              id: 'o1',
+              entity: 'region',
+              parent: { foo: 'bar' },
+              attributes: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    const store = new DiagramDomainStore();
+    await assert.rejects(
+      () => store.load(diagramId),
+      /Corrupt diagram domain state/i,
+    );
+  });
+
+  if (prev === undefined) delete process.env.DIAGRAMS_DIR;
+  else process.env.DIAGRAMS_DIR = prev;
+}
+
+async function testDomainStoreNormalizesParent() {
+  const prev = process.env.DIAGRAMS_DIR;
+
+  await withTempDir(async (dir) => {
+    process.env.DIAGRAMS_DIR = dir;
+
+    const diagramId = 'd2';
+    const filePath = path.join(dir, `${diagramId}.domain.json`);
+
+    await fs.writeFile(
+      filePath,
+      JSON.stringify(
+        {
+          version: 1,
+          objects: [
+            {
+              id: 'o1',
+              entity: 'site',
+              parent: { entity: ' region ', id: ' r1 ' },
+              attributes: { name: 'Site 1' },
+            },
+            {
+              id: 'o2',
+              entity: 'tenant',
+              parent: { root: 'definitions' },
+              attributes: {},
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    const store = new DiagramDomainStore();
+    const state = await store.load(diagramId);
+
+    assert.equal(state.objects.length, 2);
+    assert.deepEqual(state.objects[0].parent, { entity: 'region', id: 'r1' });
+    assert.deepEqual(state.objects[1].parent, { root: 'definitions' });
+  });
+
+  if (prev === undefined) delete process.env.DIAGRAMS_DIR;
+  else process.env.DIAGRAMS_DIR = prev;
+}
+
+async function testNetboxConfigAllowsMissingStyles() {
+  const prev = process.env.NETBOX_CONFIG_DIR;
+
+  await withTempDir(async (dir) => {
+    process.env.NETBOX_CONFIG_DIR = dir;
+
+    await fs.writeFile(
+      path.join(dir, 'netbox-model.yaml'),
+      [
+        'version: 1',
+        'roots:',
+        '  definitions: {}',
+        '  infrastructure: {}',
+        'entities: {}',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    await fs.writeFile(
+      path.join(dir, 'netbox-to-mermaid.yaml'),
+      [
+        'version: 1',
+        'kind: netbox-to-mermaid',
+        'roots:',
+        '  definitions:',
+        '    mermaid: { type: subgraph, id: definitions, label: "*Definitions*" }',
+        '  infrastructure:',
+        '    mermaid: { type: subgraph, id: infrastructure, label: "*Infrastructure*" }',
+        'entities: {}',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const svc = new NetboxConfigService();
+    await svc.onModuleInit();
+
+    const styles = svc.getStyles();
+    assert.ok(styles);
+    assert.ok(typeof (styles as any).version !== 'undefined');
+  });
+
+  if (prev === undefined) delete process.env.NETBOX_CONFIG_DIR;
+  else process.env.NETBOX_CONFIG_DIR = prev;
+}
+
+async function testNetboxConfigErrorsAreActionable() {
+  const prev = process.env.NETBOX_CONFIG_DIR;
+
+  await withTempDir(async (dir) => {
+    process.env.NETBOX_CONFIG_DIR = dir;
+
+    // Missing required model.entities
+    await fs.writeFile(
+      path.join(dir, 'netbox-model.yaml'),
+      [
+        'version: 1',
+        'roots:',
+        '  definitions: {}',
+        '  infrastructure: {}',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    await fs.writeFile(
+      path.join(dir, 'netbox-to-mermaid.yaml'),
+      [
+        'version: 1',
+        'kind: netbox-to-mermaid',
+        'roots: {}',
+        'entities: {}',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const svc = new NetboxConfigService();
+    await assert.rejects(
+      () => svc.onModuleInit(),
+      (err: any) => {
+        const msg = String(err?.message ?? err);
+        return msg.includes("missing required section 'entities'") && msg.includes('netbox-model.yaml');
+      },
+    );
+  });
+
+  if (prev === undefined) delete process.env.NETBOX_CONFIG_DIR;
+  else process.env.NETBOX_CONFIG_DIR = prev;
+}
+
+async function main() {
+  await testDomainStoreRejectsInvalidParent();
+  await testDomainStoreNormalizesParent();
+  await testNetboxConfigAllowsMissingStyles();
+  await testNetboxConfigErrorsAreActionable();
+
+  // eslint-disable-next-line no-console
+  console.log('diagram-domain-store.test.ts: OK');
+}
+
+main().catch((err) => {
+  // eslint-disable-next-line no-console
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
Implements the approved backend tech-debt fixes for #35 to satisfy issue #8 criterion 1 (technical debt identified/prioritized and critical items resolved).

What changed
- Opt-in sample diagram seeding via SEED_SAMPLE_DIAGRAMS (no implicit writes on boot by default)
- Replace CSV generator DI string token with a unique Symbol token
- Improve NetBox YAML config load/validation errors (actionable messages with file paths/sections); make mermaid-styles.yaml optional
- Validate domain state parent shape on load; reject corrupt persisted state deterministically

Verification
- Backend tests pass (run in Docker image)
- docker compose production mode: /health, /api/health, /api/docs respond

Closes #35