### PR TITLE
ci: build & publish Docker images + INSTALL

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,96 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to publish (defaults to git tag vX.Y.Z on HEAD, else 'mvp')."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Ensure main branch
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "This workflow only publishes images from the main branch. Current ref: ${GITHUB_REF}" >&2
+            exit 1
+          fi
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Compute version
+        id: version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+
+          VERSION=""
+
+          # Prefer explicit workflow_dispatch input when provided.
+          if [[ -n "${INPUT_VERSION}" ]]; then
+            VERSION="${INPUT_VERSION}"
+          else
+            TAG=$(git tag --points-at "${GITHUB_SHA}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+([-.].*)?$' | head -n 1 || true)
+            if [[ -n "${TAG}" ]]; then
+              VERSION="${TAG}"
+            else
+              VERSION="mvp"
+            fi
+          fi
+
+          echo "Resolved version: ${VERSION}"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build & push backend image
+        uses: docker/build-push-action@v6
+        with:
+          context: services/backend
+          file: services/backend/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:backend-${{ steps.version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:backend-latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
+
+      - name: Build & push frontend image
+        uses: docker/build-push-action@v6
+        with:
+          context: services/frontend
+          file: services/frontend/Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:frontend-${{ steps.version.outputs.version }}
+            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPOSITORY }}:frontend-latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha,scope=frontend
+          cache-to: type=gha,mode=max,scope=frontend

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,133 @@
+# Installation & Running
+
+This repository ships a minimal MVP with two services:
+
+- Backend (NestJS) on port 3000
+- Frontend (NextJS) on port 3001 (maps to container port 3000)
+
+## 1) Development (Docker images)
+
+Build images locally:
+
+    docker build -t demo-ai-native-sdlc-backend:local ./services/backend
+    docker build -t demo-ai-native-sdlc-frontend:local ./services/frontend
+
+Run backend:
+
+    docker run --rm -p 3000:3000 \
+      -e PORT=3000 \
+      -e APP_ENV=local \
+      -e APP_NAME=demo-ai-native-sdlc-backend \
+      -e NODE_ENV=production \
+      demo-ai-native-sdlc-backend:local
+
+Run frontend (talks to backend via your host network):
+
+    docker run --rm -p 3001:3000 \
+      -e NODE_ENV=production \
+      -e NEXT_PUBLIC_API_BASE_URL=http://localhost:3000 \
+      demo-ai-native-sdlc-frontend:local
+
+## 2) Development (Docker Compose)
+
+Build and run the full stack:
+
+    docker compose up --build -d
+
+Stop and remove containers:
+
+    docker compose down
+
+Remove containers and the diagrams volume (destructive):
+
+    docker compose down -v
+
+## 3) Local checks
+
+Backend:
+- Health: http://localhost:3000/health
+- API health: http://localhost:3000/api/health
+- Swagger/OpenAPI: http://localhost:3000/api/docs
+
+Frontend:
+- UI: http://localhost:3001
+
+## 4) CI pipeline overview (Docker publish)
+
+Workflow file:
+- .github/workflows/docker-publish.yml
+
+Triggers:
+- Push to main (e.g. PR merged)
+- Manual run via GitHub Actions (workflow_dispatch)
+
+Publishing:
+- Logs in to Docker Hub using the repository secrets:
+  - DOCKERHUB_USERNAME
+  - DOCKERHUB_TOKEN
+  - DOCKERHUB_REPOSITORY
+
+Image naming:
+- Base repository: DOCKERHUB_USERNAME/DOCKERHUB_REPOSITORY
+- Two images are published to the same repository, disambiguated by tags.
+
+Tag scheme:
+- Version source:
+  - If HEAD is tagged with vX.Y.Z (or vX.Y.Z-suffix), that tag is used as the version
+  - Otherwise the version defaults to mvp
+- Published tags (main branch only):
+  - Backend:
+    - DOCKERHUB_USERNAME/DOCKERHUB_REPOSITORY:backend-<version>
+    - DOCKERHUB_USERNAME/DOCKERHUB_REPOSITORY:backend-latest
+  - Frontend:
+    - DOCKERHUB_USERNAME/DOCKERHUB_REPOSITORY:frontend-<version>
+    - DOCKERHUB_USERNAME/DOCKERHUB_REPOSITORY:frontend-latest
+
+Manual trigger notes:
+- In GitHub Actions, pick the workflow “Docker Publish” and click “Run workflow”.
+- Run it from the main branch. (The workflow refuses to publish from other branches.)
+- Optionally provide an explicit version input (otherwise it uses git tag vX.Y.Z on HEAD, else mvp).
+
+## 5) Production run (Docker Compose)
+
+The production compose file pulls published images from Docker Hub:
+- docker-compose.prod.yml
+
+Run (defaults to IMAGE_TAG=mvp):
+
+    export DOCKERHUB_USERNAME=elyskov
+    export DOCKERHUB_REPOSITORY=demo-ai-native-sdlc
+    export IMAGE_TAG=mvp
+    docker compose -f docker-compose.prod.yml up -d
+
+Verify:
+
+    curl -sf http://localhost:3000/api/health
+    curl -sf http://localhost:3001
+
+Stop:
+
+    docker compose -f docker-compose.prod.yml down
+
+## Manual test plan (CI)
+
+1) workflow_dispatch on main
+- Run the workflow manually
+- Confirm images exist on Docker Hub with tags backend-mvp/frontend-mvp (or backend-vX.Y.Z/frontend-vX.Y.Z if tagged)
+
+2) Merge trigger
+- Merge a small PR to main
+- Confirm the workflow runs and pushes backend-latest/frontend-latest plus backend-<version>/frontend-<version>
+
+3) Pull and run prod compose
+- On a clean machine:
+
+    export DOCKERHUB_USERNAME=<your user>
+    export DOCKERHUB_REPOSITORY=<repo>
+    export IMAGE_TAG=mvp
+    docker compose -f docker-compose.prod.yml up -d
+    curl -sf http://localhost:3000/api/health
+    curl -sf http://localhost:3001
+
+4) Regression: frontend -> backend connectivity
+- Open the frontend and confirm it can call backend APIs

--- a/README.md
+++ b/README.md
@@ -33,39 +33,12 @@ Prerequisites
 - Node.js (LTS recommended)
 - Docker & Docker Compose (for local container workflows)
 
-Backend (Nest.js)
-----------------
+Installation / Running
+----------------------
 
-The backend lives in `services/backend`.
+See INSTALL.md for:
 
-Run with Docker (image)
-~~~~~~~~~~~~~~~~~~~~~~
-
-- Build: `docker build -t demo-ai-native-sdlc-backend:local ./services/backend`
-- Run: `docker run --rm -p 3000:3000 -e APP_ENV=local -e APP_NAME=demo-ai-native-sdlc-backend demo-ai-native-sdlc-backend:local`
-
-Run with Docker Compose
-~~~~~~~~~~~~~~~~~~~~~~~
-
-- Start: `docker compose up --build`
-
-Check locally
-~~~~~~~~~~~~~
-
-- Health endpoint: http://localhost:3000/health
-
-Frontend (Next.js)
-------------------
-
-The frontend lives in `services/frontend` and uses the Next.js App Router.
-
-Run with Docker Compose
-~~~~~~~~~~~~~~~~~~~~~~~
-
-- Start: `docker compose up --build`
-
-Check locally
-~~~~~~~~~~~~~
-
-- Frontend: http://localhost:3001
-- Backend: http://localhost:3000
+- Local development (Docker images + Docker Compose)
+- Local verification URLs (health, Swagger, frontend)
+- CI pipeline behavior (Docker publish)
+- Production run via docker-compose.prod.yml

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,25 @@
+services:
+  backend:
+    image: "${DOCKERHUB_USERNAME:-elyskov}/${DOCKERHUB_REPOSITORY:-demo-ai-native-sdlc}:backend-${IMAGE_TAG:-mvp}"
+    ports:
+      - "3000:3000"
+    environment:
+      PORT: "3000"
+      APP_NAME: "demo-ai-native-sdlc-backend"
+      APP_ENV: "production"
+      NODE_ENV: "production"
+    volumes:
+      - backend_diagrams:/app/diagrams
+
+  frontend:
+    image: "${DOCKERHUB_USERNAME:-elyskov}/${DOCKERHUB_REPOSITORY:-demo-ai-native-sdlc}:frontend-${IMAGE_TAG:-mvp}"
+    ports:
+      - "3001:3000"
+    environment:
+      NODE_ENV: "production"
+      NEXT_PUBLIC_API_BASE_URL: "http://backend:3000"
+    depends_on:
+      - backend
+
+volumes:
+  backend_diagrams:


### PR DESCRIPTION
Implements the CI + INSTALL criterion for issue #8 by adding a Docker publish workflow, a production compose file that runs from published images, and consolidated installation docs.

What changed
- GitHub Actions workflow: builds and pushes backend/frontend images to Docker Hub on push to main and on manual trigger (main branch only)
- Production compose: docker-compose.prod.yml pulls published images (no local builds)
- Docs: INSTALL.md added; README.md now points to INSTALL.md instead of duplicating run instructions

Tag scheme (documented in INSTALL.md)
- Version: git tag vX.Y.Z on HEAD if present; otherwise mvp
- Backend tags: backend-<version>, backend-latest
- Frontend tags: frontend-<version>, frontend-latest

Validation
- docker compose config passes for both compose files

Closes #37