### PR TITLE
Align netbox-model.yaml schema with NetBox requests

### DIFF
--- a/docs/agents/ARCHITECTURE.md
+++ b/docs/agents/ARCHITECTURE.md
@@ -39,6 +39,8 @@ Backend behavior is driven by YAML configuration (see backend README for env var
 - `netbox-to-mermaid.yaml` defines Mermaid ids, templates, and roots.
 - `mermaid-styles.yaml` is optional (styling is skipped if missing).
 
+See [docs/architecture/NETBOX-MODEL.md](../architecture/NETBOX-MODEL.md) for the detailed `netbox-model.yaml` schema and validation rules.
+
 ## CSV export rules
 
 - Output must be deterministic and documented.

--- a/docs/architecture/NETBOX-MODEL.md
+++ b/docs/architecture/NETBOX-MODEL.md
@@ -1,0 +1,351 @@
+# NetBox Model Config (`netbox-model.yaml`)
+
+This document describes the configuration schema, semantics, and validation rules for the NetBox model configuration file used by the backend.
+
+The backend uses this file as a **single source of truth** for:
+- which entities exist,
+- how entities can be nested (`parent`) and related (`links`),
+- which attributes exist and how they are validated,
+- the deterministic attribute ordering used by Mermaid generation and CSV export.
+
+## Location and loading
+
+- The backend loads YAML from `NETBOX_CONFIG_DIR` (default: `<backend cwd>/config`).
+- Required files:
+  - `netbox-model.yaml` (this document)
+  - `netbox-to-mermaid.yaml`
+- Optional file:
+  - `mermaid-styles.yaml` (backend will warn and continue if missing)
+
+## Top-level schema
+
+```yaml
+version: 1
+roots: { ... }
+field_groups: { ... }          # optional
+entities: { ... }
+```
+
+### `version`
+
+Type: `number | string`.
+
+Used for human tracking and forward compatibility.
+
+### `roots`
+
+Type: `Record<string, { description?: string }>`.
+
+Roots represent top-level containers in the domain model (and typically Mermaid subgraphs).
+
+Example:
+
+```yaml
+roots:
+  definitions:
+    description: "Logical definitions and catalogs"
+  infrastructure:
+    description: "Physical and logical infrastructure"
+```
+
+### `field_groups` (optional)
+
+Type: `Record<string, { attributes?: Record<string, AttributeDefinition> }>`.
+
+Field groups are reusable attribute bundles to avoid repeating common attribute definitions across entities.
+
+Example:
+
+```yaml
+field_groups:
+  name_slug:
+    attributes:
+      name:
+        required: true
+        maxLength: 100
+      slug:
+        required: true
+        pattern: ^[-a-zA-Z0-9_]+$
+```
+
+### `entities`
+
+Type: `Record<string, EntityConfig>`.
+
+Each entity key is the domain entity type (for example `site`, `device`, `tenant-group`).
+
+## Entity schema
+
+```yaml
+entities:
+  <entityKey>:
+    meta: { ... }                 # optional, opaque to validation
+    capabilities: { ... }         # optional
+    include_groups: [ ... ]       # optional
+    parent: { ... }               # optional
+    links: { ... }                # optional
+    attributes: { ... }           # optional
+```
+
+### `meta` (optional)
+
+Type: `Record<string, unknown>`.
+
+`meta` is allowed for storing UI or integration hints (for example `api_prefix`, `object`, grouping fields). The backend model validator does **not** enforce a schema for `meta`.
+
+### `capabilities` (optional)
+
+Type:
+
+```yaml
+capabilities:
+  custom_fields: true|false
+```
+
+- `custom_fields` indicates that the entity supports NetBox custom fields.
+- This is a **capability flag only**.
+  - The configuration does not enumerate custom field keys.
+  - Custom field keys/values are expected to live in diagram content or external inputs.
+
+Validation rule:
+- `capabilities` must be an object if present.
+- `capabilities.custom_fields` must be a boolean if present.
+
+### `include_groups` (optional)
+
+Type: `string[]`.
+
+Declares which `field_groups` should be merged into this entity’s attribute set.
+
+Merge rules (important):
+- If `include_groups` is present, `field_groups` must be present.
+- Each referenced group key must exist in `field_groups`.
+- At load time the backend **expands** attributes so downstream code sees a single merged `attributes` map.
+- Merge order:
+  1) attributes from the included groups (in the order listed)
+  2) entity-local `attributes` override group attributes by key
+- If multiple groups define the same attribute key, the first group wins (later groups do not overwrite it). Entity-local attributes always override.
+
+Notes:
+- Attribute ordering matters; this merge order is also the ordering used by generators.
+
+### `parent` (optional)
+
+Controls whether the entity must have a parent and which parent types are allowed.
+
+Schema:
+
+```yaml
+parent:
+  required: true|false
+  allowed:
+    - root: <rootKey>
+      field: <netboxFieldName>
+    - entity: <entityKey>
+      field: <netboxFieldName>
+```
+
+Semantics:
+- If `parent.required: true`, create/move operations must supply a parent.
+- `allowed` is interpreted as a set of allowed parent contexts.
+  - `root` entries allow placing the entity directly under a root.
+  - `entity` entries allow placing the entity under another entity.
+- `field` records the NetBox API field name used for that relationship in CSV/import semantics.
+
+### `links` (optional)
+
+Links represent additional relations (besides the parent relation) that map to NetBox API fields.
+
+Schema:
+
+```yaml
+links:
+  <linkKey>:
+    entity: <entityKey>
+    field: <netboxFieldName>
+    required: true|false
+```
+
+Semantics:
+- A link points to another entity type.
+- `field` records the NetBox API field name.
+- For the current phase, relations are treated as **id-only** in data export and integration assumptions.
+
+### `attributes` (optional)
+
+Type: `Record<string, AttributeDefinition>`.
+
+Attributes are key/value fields stored on diagram objects and validated on create/update. Attribute ordering is preserved.
+
+## AttributeDefinition
+
+An attribute definition describes validation and type coercion rules for a single attribute.
+
+### Supported types
+
+Scalar types:
+- `string` (default if omitted)
+- `number`
+- `integer`
+- `boolean`
+
+Composite type:
+- `array` (one level only)
+
+Schema (scalar):
+
+```yaml
+<attrKey>:
+  required: true|false        # optional
+  nullable: true|false        # optional
+  type: string|number|integer|boolean
+  maxLength: <int>            # string-only
+  pattern: <regex>            # string/number/integer supported
+  minimum: <number>           # number/integer only
+  maximum: <number>           # number/integer only
+  value: [ ... ]              # enum values (string|number|boolean)
+  label: [ ... ]              # optional labels, same length as value
+```
+
+Schema (array):
+
+```yaml
+<attrKey>:
+  type: array
+  nullable: true|false        # optional
+  items:
+    type: string|number|integer|boolean
+    # ... scalar rules apply here
+```
+
+### Validation and coercion rules
+
+General:
+- Missing/empty values:
+  - A value is considered “empty” if it is `null`, `undefined`, or the empty string after trimming.
+  - If `nullable: true` and the value is empty, validation is skipped (even if other rules exist).
+  - If `required: true` and the value is empty, validation fails.
+
+Scalar coercion:
+- `string`: accepts string; also accepts number/boolean and stringifies them.
+- `boolean`: accepts boolean; accepts strings `"true"`/`"false"` (case-insensitive).
+- `number`/`integer`: accepts number; accepts numeric strings; rejects non-finite values.
+- `integer`: additionally rejects decimals.
+
+Scalar constraints:
+- `maxLength`:
+  - only meaningful for `string`.
+  - if omitted for string, runtime validation defaults to `100`.
+- `pattern`:
+  - the regex must compile as a JavaScript `RegExp`.
+  - for `number`/`integer`, the pattern is tested against the original input string when available.
+- `value`/`label`:
+  - `value` must be a non-empty array.
+  - `label` is optional but if present:
+    - requires `value`
+    - must be an array of strings
+    - must be the same length as `value`
+
+Numeric constraints:
+- `minimum` and `maximum` must be finite numbers if present.
+- `minimum <= maximum` when both are present.
+
+Array constraints:
+- `type: array` requires `items` to be present and an object.
+- Nested arrays (`array` within `items`) are not supported.
+- For arrays, scalar-only fields like `pattern`, `maxLength`, `value`, `minimum`, etc. must be placed under `items`.
+- Runtime validation requires the value to be a JSON array.
+- Each array element is validated with the `items` schema.
+- Empty elements (null/undefined/empty-string) are rejected.
+
+## Common conventions used in this repo
+
+### Tags (`tags`)
+
+For entities that support tagging in NetBox, this repo models tags as:
+
+```yaml
+tags:
+  type: array
+  nullable: true
+  items:
+    type: string
+    pattern: ^[-a-zA-Z0-9_]+$
+```
+
+Interpretation:
+- Tags are represented as an array of **slugs** (strings).
+- This aligns with “id-only” and CSV-friendly conventions for the current phase.
+
+### Custom fields (`custom_fields`)
+
+Entities that support NetBox custom fields can be marked with:
+
+```yaml
+capabilities:
+  custom_fields: true
+```
+
+This is intentionally a capability flag only; the model does not define keys.
+
+## Examples
+
+### Minimal entity
+
+```yaml
+entities:
+  region:
+    parent:
+      required: true
+      allowed:
+        - root: infrastructure
+          field: parent
+    links: {}
+    attributes:
+      name:
+        required: true
+      slug:
+        required: true
+        pattern: ^[-a-zA-Z0-9_]+$
+```
+
+### Entity using field group + tags
+
+```yaml
+field_groups:
+  name_slug:
+    attributes:
+      name: { required: true, maxLength: 100 }
+      slug: { required: true, pattern: ^[-a-zA-Z0-9_]+$ }
+
+entities:
+  site:
+    include_groups: [name_slug]
+    capabilities:
+      custom_fields: true
+    attributes:
+      status:
+        required: true
+        value: [planned, active]
+        label: [Planned, Active]
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
+```
+
+## Implementation notes (backend)
+
+- Model validation is performed during backend startup.
+- `include_groups` expansion is performed during config load so downstream services see merged `attributes`.
+- Attribute validation is applied during diagram create/update operations.
+- CSV and Mermaid generation use the attribute key order from the resolved (expanded) model.
+
+## Known limitations (current phase)
+
+- Only scalar and one-level `array` attributes are supported.
+- Object/map attribute types are not modeled.
+- Filtering/query parameter schema is not modeled here.
+- Relations are treated as **id-only** in this phase (NetBox request schemas sometimes accept “id or object”).

--- a/services/backend/config/netbox-model.yaml
+++ b/services/backend/config/netbox-model.yaml
@@ -6,6 +6,16 @@ roots:
   infrastructure:
     description: "Physical and logical infrastructure"
 
+field_groups:
+  name_slug:
+    attributes:
+      name:
+        required: true
+        maxLength: 100
+      slug:
+        required: true
+        pattern: ^[-a-zA-Z0-9_]+$
+
 entities:
 
   region:
@@ -24,13 +34,18 @@ entities:
 
     links: {}
 
+    capabilities:
+      custom_fields: true
+
+    include_groups: [name_slug]
+
     attributes:
-      name:
-        required: true
-        maxLength: 100
-      slug:
-        required: true
-        pattern: ^[-a-zA-Z0-9_]+$
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   site-group:
@@ -49,11 +64,18 @@ entities:
 
     links: {}
 
+    capabilities:
+      custom_fields: true
+
+    include_groups: [name_slug]
+
     attributes:
-      name:
-        required: true
-      slug:
-        required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   site:
@@ -80,11 +102,12 @@ entities:
         field: group
         required: false
 
+    capabilities:
+      custom_fields: true
+
+    include_groups: [name_slug]
+
     attributes:
-      name:
-        required: true
-      slug:
-        required: true
       status:
         required: true
         value: [planned, staging, active, decommissioning, retired]
@@ -95,6 +118,12 @@ entities:
         nullable: true
         minimum: -90
         maximum: 90
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   location:
@@ -121,13 +150,20 @@ entities:
         field: tenant
         required: false
 
+    capabilities:
+      custom_fields: true
+
+    include_groups: [name_slug]
+
     attributes:
-      name:
-        required: true
-      slug:
-        required: true
       status:
         required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   tenant-group:
@@ -146,11 +182,18 @@ entities:
 
     links: {}
 
+    capabilities:
+      custom_fields: true
+
+    include_groups: [name_slug]
+
     attributes:
-      name:
-        required: true
-      slug:
-        required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   tenant:
@@ -169,11 +212,18 @@ entities:
 
     links: {}
 
+    capabilities:
+      custom_fields: true
+
+    include_groups: [name_slug]
+
     attributes:
-      name:
-        required: true
-      slug:
-        required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   rack-type:
@@ -190,6 +240,9 @@ entities:
           field: manufacturer
 
     links: {}
+
+    capabilities:
+      custom_fields: true
 
     attributes:
       slug:
@@ -210,6 +263,12 @@ entities:
         required: true
       starting_unit:
         required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   rack:
@@ -244,6 +303,9 @@ entities:
         field: role
         required: false
 
+    capabilities:
+      custom_fields: true
+
     attributes:
       name:
         required: true
@@ -255,6 +317,12 @@ entities:
         required: true
       starting_unit:
         required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   manufacturer:
@@ -271,11 +339,18 @@ entities:
 
     links: {}
 
+    capabilities:
+      custom_fields: true
+
+    include_groups: [name_slug]
+
     attributes:
-      name:
-        required: true
-      slug:
-        required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   device-role:
@@ -298,14 +373,21 @@ entities:
         field: config_template
         required: false
 
+    capabilities:
+      custom_fields: true
+
+    include_groups: [name_slug]
+
     attributes:
-      name:
-        required: true
-      slug:
-        required: true
       color:
         required: true
         pattern: ^[0-9a-f]{6}$
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   platform:
@@ -332,11 +414,18 @@ entities:
         field: config_template
         required: false
 
+    capabilities:
+      custom_fields: true
+
+    include_groups: [name_slug]
+
     attributes:
-      name:
-        required: true
-      slug:
-        required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   device-type:
@@ -361,6 +450,9 @@ entities:
         field: default_platform
         required: true
 
+    capabilities:
+      custom_fields: true
+
     attributes:
       slug:
         required: true
@@ -368,6 +460,12 @@ entities:
         required: true
       u_height:
         required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   virtual-chassis:
@@ -384,9 +482,18 @@ entities:
 
     links: {}
 
+    capabilities:
+      custom_fields: true
+
     attributes:
       name:
         required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   device:
@@ -435,11 +542,20 @@ entities:
         field: virtual_chassis
         required: false
 
+    capabilities:
+      custom_fields: true
+
     attributes:
       name:
         required: false
       status:
         required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$
 
 
   interface:
@@ -457,8 +573,17 @@ entities:
 
     links: {}
 
+    capabilities:
+      custom_fields: true
+
     attributes:
       name:
         required: true
       type:
         required: true
+      tags:
+        type: array
+        nullable: true
+        items:
+          type: string
+          pattern: ^[-a-zA-Z0-9_]+$

--- a/services/backend/src/diagrams/commands/attribute-validation.ts
+++ b/services/backend/src/diagrams/commands/attribute-validation.ts
@@ -1,7 +1,11 @@
-import type { NetboxAttributeDefinition, NetboxAttributeType } from '../../netbox-config/netbox-config.models';
+import type {
+  NetboxAttributeDefinition,
+  NetboxAttributeScalarType,
+  NetboxAttributeType,
+} from '../../netbox-config/netbox-config.models';
 
 export type CoercedAttributeValue = {
-  type: NetboxAttributeType;
+  type: NetboxAttributeScalarType;
   raw: unknown;
   rawString: string;
   value: string | number | boolean;
@@ -13,7 +17,7 @@ function isEmptyValue(value: unknown): boolean {
   return false;
 }
 
-function coerceValue(entity: string, key: string, type: NetboxAttributeType, raw: unknown): CoercedAttributeValue {
+function coerceScalarValue(entity: string, key: string, type: NetboxAttributeScalarType, raw: unknown): CoercedAttributeValue {
   const rawString = typeof raw === 'string' ? raw.trim() : String(raw);
 
   if (type === 'string') {
@@ -68,6 +72,50 @@ function coerceValue(entity: string, key: string, type: NetboxAttributeType, raw
   throw new Error(`Invalid attribute '${key}' for '${entity}': unsupported type '${type}'`);
 }
 
+function validateScalarRules(entity: string, key: string, coerced: CoercedAttributeValue, def: NetboxAttributeDefinition) {
+  const type = coerced.type;
+
+  if (type === 'string') {
+    const maxLength = def.maxLength ?? 100;
+    const s = String(coerced.value);
+    if (s.length > maxLength) {
+      throw new Error(`Invalid attribute '${key}' for '${entity}': exceeds maxLength ${maxLength}`);
+    }
+  }
+
+  if (def.pattern) {
+    const re = new RegExp(def.pattern);
+    // For numbers/integers we validate the original string input format when possible.
+    const testValue = (type === 'number' || type === 'integer') ? coerced.rawString : String(coerced.value);
+    if (!re.test(testValue)) {
+      throw new Error(`Invalid attribute '${key}' for '${entity}': does not match pattern ${def.pattern}`);
+    }
+  }
+
+  if (def.value) {
+    const allowed = def.value;
+    const ok =
+      type === 'string'
+        ? allowed.some((v) => String(v) === String(coerced.value))
+        : allowed.some((v) => v === coerced.value);
+    if (!ok) {
+      throw new Error(`Invalid attribute '${key}' for '${entity}': must be one of [${allowed.join(', ')}]`);
+    }
+  }
+
+  if (type === 'number' || type === 'integer') {
+    const num = coerced.value as number;
+
+    if (def.minimum !== undefined && num < def.minimum) {
+      throw new Error(`Invalid attribute '${key}' for '${entity}': must be >= ${def.minimum}`);
+    }
+
+    if (def.maximum !== undefined && num > def.maximum) {
+      throw new Error(`Invalid attribute '${key}' for '${entity}': must be <= ${def.maximum}`);
+    }
+  }
+}
+
 export function validateEntityAttributes(entity: string, attrs: Record<string, any>, definitions: Record<string, NetboxAttributeDefinition> | undefined) {
   const defs = definitions ?? {};
 
@@ -86,46 +134,34 @@ export function validateEntityAttributes(entity: string, attrs: Record<string, a
       continue;
     }
 
-    const coerced = coerceValue(entity, key, type, raw);
-
-    if (type === 'string') {
-      const maxLength = def.maxLength ?? 100;
-      const s = String(coerced.value);
-      if (s.length > maxLength) {
-        throw new Error(`Invalid attribute '${key}' for '${entity}': exceeds maxLength ${maxLength}`);
+    if (type === 'array') {
+      if (!Array.isArray(raw)) {
+        throw new Error(`Invalid attribute '${key}' for '${entity}': expected array`);
       }
+
+      const itemsDef = def.items;
+      if (!itemsDef) {
+        throw new Error(`Invalid attribute '${key}' for '${entity}': missing items definition`);
+      }
+      const itemType = (itemsDef.type ?? 'string') as NetboxAttributeType;
+      if (itemType === 'array') {
+        throw new Error(`Invalid attribute '${key}' for '${entity}': nested arrays are not supported`);
+      }
+
+      for (let i = 0; i < raw.length; i += 1) {
+        const itemRaw = raw[i];
+        if (isEmptyValue(itemRaw)) {
+          throw new Error(`Invalid attribute '${key}[${i}]' for '${entity}': empty value`);
+        }
+
+        const coerced = coerceScalarValue(entity, `${key}[${i}]`, itemType as NetboxAttributeScalarType, itemRaw);
+        validateScalarRules(entity, `${key}[${i}]`, coerced, itemsDef);
+      }
+
+      continue;
     }
 
-    if (def.pattern) {
-      const re = new RegExp(def.pattern);
-      // For numbers/integers we validate the original string input format when possible.
-      const testValue = (type === 'number' || type === 'integer') ? coerced.rawString : String(coerced.value);
-      if (!re.test(testValue)) {
-        throw new Error(`Invalid attribute '${key}' for '${entity}': does not match pattern ${def.pattern}`);
-      }
-    }
-
-    if (def.value) {
-      const allowed = def.value;
-      const ok =
-        type === 'string'
-          ? allowed.some((v) => String(v) === String(coerced.value))
-          : allowed.some((v) => v === coerced.value);
-      if (!ok) {
-        throw new Error(`Invalid attribute '${key}' for '${entity}': must be one of [${allowed.join(', ')}]`);
-      }
-    }
-
-    if (type === 'number' || type === 'integer') {
-      const num = coerced.value as number;
-
-      if (def.minimum !== undefined && num < def.minimum) {
-        throw new Error(`Invalid attribute '${key}' for '${entity}': must be >= ${def.minimum}`);
-      }
-
-      if (def.maximum !== undefined && num > def.maximum) {
-        throw new Error(`Invalid attribute '${key}' for '${entity}': must be <= ${def.maximum}`);
-      }
-    }
+    const coerced = coerceScalarValue(entity, key, type as NetboxAttributeScalarType, raw);
+    validateScalarRules(entity, key, coerced, def);
   }
 }

--- a/services/backend/src/netbox-config/netbox-config.models.ts
+++ b/services/backend/src/netbox-config/netbox-config.models.ts
@@ -1,9 +1,12 @@
-export type NetboxAttributeType = 'string' | 'number' | 'integer' | 'boolean';
+export type NetboxAttributeScalarType = 'string' | 'number' | 'integer' | 'boolean';
+
+export type NetboxAttributeType = NetboxAttributeScalarType | 'array';
 
 export type NetboxAttributeDefinition = {
   required?: boolean;
   maxLength?: number;
   type?: NetboxAttributeType;
+  items?: NetboxAttributeDefinition;
   pattern?: string;
   value?: Array<string | number | boolean>;
   label?: string[];
@@ -12,13 +15,22 @@ export type NetboxAttributeDefinition = {
   maximum?: number;
 };
 
+export type NetboxFieldGroup = {
+  attributes?: Record<string, NetboxAttributeDefinition>;
+};
+
 export type NetboxModelConfig = {
   version: number | string;
   roots: Record<string, { description?: string }>;
+  field_groups?: Record<string, NetboxFieldGroup>;
   entities: Record<
     string,
     {
       meta?: Record<string, unknown>;
+      capabilities?: {
+        custom_fields?: boolean;
+      };
+      include_groups?: string[];
       parent?: {
         required?: boolean;
         allowed?: Array<{ root?: string; entity?: string; field?: string }>;

--- a/services/backend/src/netbox-config/netbox-config.service.ts
+++ b/services/backend/src/netbox-config/netbox-config.service.ts
@@ -6,6 +6,7 @@ import * as yaml from 'js-yaml';
 import type {
   LoadedNetboxConfig,
   MermaidStylesConfig,
+  NetboxAttributeDefinition,
   NetboxModelConfig,
   NetboxToMermaidConfig,
 } from './netbox-config.models';
@@ -43,6 +44,8 @@ export class NetboxConfigService implements OnModuleInit {
       : this.defaultStylesConfig();
 
     this.validateModelConfig(model, modelPath);
+
+    const expandedModel = this.expandModelFieldGroups(model);
     this.validateMappingConfig(mapping, mappingPath);
 
     if (stylesRaw) {
@@ -51,10 +54,10 @@ export class NetboxConfigService implements OnModuleInit {
       this.logger.warn(`Mermaid styles config not found at ${stylesPath}; continuing without styles`);
     }
 
-    this.loaded = { model, mapping, styles };
+    this.loaded = { model: expandedModel, mapping, styles };
 
     this.logger.log(
-      `Loaded NetBox config: ${Object.keys(model.entities).length} entities, ${Object.keys(mapping.roots).length} roots`,
+      `Loaded NetBox config: ${Object.keys(expandedModel.entities).length} entities, ${Object.keys(mapping.roots).length} roots`,
     );
   }
 
@@ -106,6 +109,45 @@ export class NetboxConfigService implements OnModuleInit {
 
   private validateModelConfig(model: NetboxModelConfig, filePath: string) {
     validateNetboxModelConfig(model, filePath);
+  }
+
+  private expandModelFieldGroups(model: NetboxModelConfig): NetboxModelConfig {
+    const groups = model.field_groups;
+    if (!groups || !Object.keys(groups).length) return model;
+
+    const entities: NetboxModelConfig['entities'] = {};
+    for (const [entityKey, entityCfg] of Object.entries(model.entities ?? {})) {
+      const includeGroups = entityCfg.include_groups ?? [];
+      if (!includeGroups.length) {
+        entities[entityKey] = entityCfg;
+        continue;
+      }
+
+      const expandedAttributes: Record<string, NetboxAttributeDefinition> = {};
+
+      for (const groupKey of includeGroups) {
+        const groupAttrs = groups[groupKey]?.attributes ?? {};
+        for (const [attrKey, attrDef] of Object.entries(groupAttrs)) {
+          if (expandedAttributes[attrKey] !== undefined) continue;
+          expandedAttributes[attrKey] = attrDef;
+        }
+      }
+
+      const entityAttrs = entityCfg.attributes ?? {};
+      for (const [attrKey, attrDef] of Object.entries(entityAttrs)) {
+        expandedAttributes[attrKey] = attrDef;
+      }
+
+      entities[entityKey] = {
+        ...entityCfg,
+        attributes: expandedAttributes,
+      };
+    }
+
+    return {
+      ...model,
+      entities,
+    };
   }
 
   private validateMappingConfig(mapping: NetboxToMermaidConfig, filePath: string) {

--- a/services/backend/src/netbox-config/netbox-model-validation.ts
+++ b/services/backend/src/netbox-config/netbox-model-validation.ts
@@ -15,13 +15,19 @@ function formatLocation(entity: string, attribute?: string): string {
 
 function assertAttributeType(type: unknown, filePath: string, entity: string, attribute: string): asserts type is NetboxAttributeType {
   if (type === undefined) return;
-  if (type === 'string' || type === 'number' || type === 'integer' || type === 'boolean') return;
+  if (type === 'string' || type === 'number' || type === 'integer' || type === 'boolean' || type === 'array') return;
   throw new Error(
     `Invalid NetBox model config: ${formatLocation(entity, attribute)} has unsupported type '${String(type)}' (${filePath})`,
   );
 }
 
-function validateAttributeDefinition(def: unknown, filePath: string, entity: string, attribute: string): asserts def is NetboxAttributeDefinition {
+function validateAttributeDefinition(
+  def: unknown,
+  filePath: string,
+  entity: string,
+  attribute: string,
+  depth = 0,
+): asserts def is NetboxAttributeDefinition {
   if (!isRecord(def)) {
     throw new Error(
       `Invalid NetBox model config: ${formatLocation(entity, attribute)} definition must be an object (${filePath})`,
@@ -29,6 +35,34 @@ function validateAttributeDefinition(def: unknown, filePath: string, entity: str
   }
 
   assertAttributeType((def as any).type, filePath, entity, attribute);
+
+  const type = (def as any).type as NetboxAttributeType | undefined;
+  if (type === 'array') {
+    if (depth >= 1) {
+      throw new Error(
+        `Invalid NetBox model config: ${formatLocation(entity, attribute)} nested arrays are not supported (${filePath})`,
+      );
+    }
+
+    const scalarOnlyFields = ['maxLength', 'pattern', 'value', 'label', 'minimum', 'maximum'] as const;
+    for (const f of scalarOnlyFields) {
+      if ((def as any)[f] !== undefined) {
+        throw new Error(
+          `Invalid NetBox model config: ${formatLocation(entity, attribute)} has '${f}' but type is 'array' (define it under 'items') (${filePath})`,
+        );
+      }
+    }
+
+    const items = (def as any).items;
+    if (!isRecord(items)) {
+      throw new Error(
+        `Invalid NetBox model config: ${formatLocation(entity, attribute)} has type 'array' but missing/invalid 'items' (${filePath})`,
+      );
+    }
+
+    validateAttributeDefinition(items, filePath, entity, `${attribute}.items`, depth + 1);
+    return;
+  }
 
   if ((def as any).maxLength !== undefined) {
     const v = (def as any).maxLength;
@@ -129,6 +163,32 @@ export function validateNetboxModelConfig(model: NetboxModelConfig, filePath: st
     throw new Error(`Invalid NetBox model config: expected a YAML object in ${filePath}`);
   }
 
+  const fieldGroups = (model as any).field_groups;
+  if (fieldGroups !== undefined) {
+    if (!isRecord(fieldGroups)) {
+      throw new Error(`Invalid NetBox model config: 'field_groups' must be an object (${filePath})`);
+    }
+
+    for (const [groupKey, groupCfg] of Object.entries(fieldGroups)) {
+      if (!isRecord(groupCfg)) {
+        throw new Error(`Invalid NetBox model config: field group '${groupKey}' must be an object (${filePath})`);
+      }
+
+      const attrs = (groupCfg as any).attributes;
+      if (attrs === undefined) continue;
+
+      if (!isRecord(attrs)) {
+        throw new Error(
+          `Invalid NetBox model config: field group '${groupKey}' attributes must be an object (${filePath})`,
+        );
+      }
+
+      for (const [attrKey, def] of Object.entries(attrs)) {
+        validateAttributeDefinition(def, filePath, `field_groups.${groupKey}`, attrKey);
+      }
+    }
+  }
+
   if (!isRecord((model as any).entities)) {
     throw new Error(
       `Invalid NetBox model config: missing required section 'entities' in ${filePath}`,
@@ -139,6 +199,43 @@ export function validateNetboxModelConfig(model: NetboxModelConfig, filePath: st
   for (const [entityKey, entityCfg] of Object.entries(entities)) {
     if (!isRecord(entityCfg)) {
       throw new Error(`Invalid NetBox model config: entity '${entityKey}' must be an object (${filePath})`);
+    }
+
+    const capabilities = (entityCfg as any).capabilities;
+    if (capabilities !== undefined) {
+      if (!isRecord(capabilities)) {
+        throw new Error(
+          `Invalid NetBox model config: entity '${entityKey}' capabilities must be an object (${filePath})`,
+        );
+      }
+      if ((capabilities as any).custom_fields !== undefined && typeof (capabilities as any).custom_fields !== 'boolean') {
+        throw new Error(
+          `Invalid NetBox model config: entity '${entityKey}' capabilities.custom_fields must be boolean (${filePath})`,
+        );
+      }
+    }
+
+    const includeGroups = (entityCfg as any).include_groups;
+    if (includeGroups !== undefined) {
+      if (!Array.isArray(includeGroups) || includeGroups.some((v) => typeof v !== 'string' || !v.trim())) {
+        throw new Error(
+          `Invalid NetBox model config: entity '${entityKey}' include_groups must be an array of non-empty strings (${filePath})`,
+        );
+      }
+
+      if (!fieldGroups) {
+        throw new Error(
+          `Invalid NetBox model config: entity '${entityKey}' uses include_groups but 'field_groups' is missing (${filePath})`,
+        );
+      }
+
+      for (const groupKey of includeGroups) {
+        if (!isRecord((fieldGroups as any)[groupKey])) {
+          throw new Error(
+            `Invalid NetBox model config: entity '${entityKey}' include_groups references unknown group '${groupKey}' (${filePath})`,
+          );
+        }
+      }
     }
 
     const attrs = (entityCfg as any).attributes;

--- a/services/backend/test/netbox-attributes-definitions.test.ts
+++ b/services/backend/test/netbox-attributes-definitions.test.ts
@@ -26,10 +26,11 @@ function expectThrows(fn: () => void, re: RegExp) {
 
 async function testModelConfigAcceptsNewFields() {
   const model = baseModel({
+    // Also validates field_groups/include_groups and array attribute types.
     site: {
+      include_groups: ['name_slug'],
       attributes: {
-        name: { required: true, maxLength: 100 },
-        slug: { required: true, pattern: '^[-a-zA-Z0-9_]+$' },
+        tags: { type: 'array', nullable: true, items: { type: 'string', pattern: '^[-a-zA-Z0-9_]+$' } },
         status: {
           required: true,
           value: ['planned', 'active'],
@@ -45,6 +46,15 @@ async function testModelConfigAcceptsNewFields() {
       },
     },
   });
+
+  (model as any).field_groups = {
+    name_slug: {
+      attributes: {
+        name: { required: true, maxLength: 100 },
+        slug: { required: true, pattern: '^[-a-zA-Z0-9_]+$' },
+      },
+    },
+  };
 
   validateNetboxModelConfig(model as any, 'netbox-model.yaml');
 }
@@ -76,6 +86,39 @@ async function testModelConfigRejectsBadRegex() {
   expectThrows(
     () => validateNetboxModelConfig(model as any, 'netbox-model.yaml'),
     /invalid pattern regex/i,
+  );
+}
+
+async function testModelConfigRejectsArrayWithoutItems() {
+  const model = baseModel({
+    region: {
+      attributes: {
+        tags: { type: 'array' },
+      },
+    },
+  });
+
+  expectThrows(
+    () => validateNetboxModelConfig(model as any, 'netbox-model.yaml'),
+    /type 'array' but missing\/invalid 'items'/i,
+  );
+}
+
+async function testModelConfigRejectsUnknownIncludeGroup() {
+  const model = baseModel({
+    site: {
+      include_groups: ['missing'],
+      attributes: {},
+    },
+  });
+
+  (model as any).field_groups = {
+    present: { attributes: { name: { required: true } } },
+  };
+
+  expectThrows(
+    () => validateNetboxModelConfig(model as any, 'netbox-model.yaml'),
+    /references unknown group/i,
   );
 }
 
@@ -179,12 +222,31 @@ async function testAttributeValidationEnumStringifiedWhenTypeString() {
   );
 }
 
+async function testAttributeValidationArrayItemsPattern() {
+  expectThrows(
+    () => validateEntityAttributes(
+      'site',
+      { tags: ['good', 'bad tag'] },
+      { tags: { type: 'array', items: { type: 'string', pattern: '^[-a-zA-Z0-9_]+$' } } },
+    ),
+    /does not match pattern/i,
+  );
+
+  validateEntityAttributes(
+    'site',
+    { tags: ['good-tag', 'tag_2'] },
+    { tags: { type: 'array', items: { type: 'string', pattern: '^[-a-zA-Z0-9_]+$' } } },
+  );
+}
+
 async function main() {
   await testModelConfigAcceptsNewFields();
   await testModelConfigRejectsUnsupportedType();
   await testModelConfigRejectsBadRegex();
+  await testModelConfigRejectsArrayWithoutItems();
   await testModelConfigRejectsLabelMismatch();
   await testModelConfigRejectsMinimumGreaterThanMaximum();
+  await testModelConfigRejectsUnknownIncludeGroup();
 
   await testAttributeValidationMaxLength();
   await testAttributeValidationPattern();
@@ -193,6 +255,7 @@ async function main() {
   await testAttributeValidationIntegerRejectsDecimals();
   await testAttributeValidationBoolean();
   await testAttributeValidationEnumStringifiedWhenTypeString();
+  await testAttributeValidationArrayItemsPattern();
 
   // eslint-disable-next-line no-console
   console.log('netbox-attributes-definitions.test.ts: OK');


### PR DESCRIPTION
## Scope
- Extend netbox-model.yaml schema to support array attributes (e.g. tags), reusable field groups, and a custom_fields capability flag.
- Expand include_groups at config load so generators/validators see merged attributes.

## Non-goals
- Model query/filter params or response/read-only fields.
- Support nested arrays or object/map attribute types (not needed yet).

## Testing
- docker compose run --rm backend-tests

Closes #51