### PR TITLE
fix(backend): ignore tsbuildinfo so Docker builds always emit dist/

### DIFF
--- a/services/backend/.dockerignore
+++ b/services/backend/.dockerignore
@@ -1,6 +1,7 @@
 node_modules
 npm-debug.log
 dist
+*.tsbuildinfo
 .git
 .vscode
 .DS_Store

--- a/services/backend/.gitignore
+++ b/services/backend/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
+*.tsbuildinfo
 .env
 .env.*


### PR DESCRIPTION
Fixes #53.

- Adds `*.tsbuildinfo` to backend `.dockerignore` and `.gitignore`.
- Prevents stale TypeScript incremental metadata from suppressing `tsc` emission inside Docker build stages.

Repro before: `docker compose up --build` can fail at `COPY --from=build /app/dist`.
After: build stage reliably produces `/app/dist`.